### PR TITLE
refactor: move radio btns to tuning form. Closes #6 closes #22

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,3 +156,9 @@ ul > ul {
   animation-name: fixFlash;
   animation-duration: 2625ms;
 }
+
+@media (min-width: 468px) {
+  button.user-tuning {
+    margin-top: 0!important;
+  }
+}

--- a/js/modules/loadLocalTuning.js
+++ b/js/modules/loadLocalTuning.js
@@ -1,4 +1,5 @@
 const numberInputElements = document.querySelectorAll('.note');
+const selectOptions = document.querySelectorAll('option');
 
 // Get the elements that show the notes for each tuning
 const sixth = document.getElementById("sixth");
@@ -8,6 +9,9 @@ const third = document.getElementById("third");
 const second = document.getElementById("second");
 const first = document.getElementById("first");
 
+const sharpRadioBtn = document.querySelector("#sharp-key");
+const flatRadioBtn = document.querySelector("#flat-key");
+
 /**
  * Check local storage and load tuning values. Use innerText to 
  * initially load the tuning if not in localStorage, else use
@@ -15,11 +19,39 @@ const first = document.getElementById("first");
  */
 export default function loadLocalTuning() {
   if (localStorage.getItem('userStrings') === null) {
+
+    // Set the text above the number inputs
     const savedUserTuning = [sixth.innerText, fifth.innerText, fourth.innerText, third.innerText, second.innerText, first.innerText];
     localStorage.setItem("userStrings", savedUserTuning);
 
+    // Set the default of Standard Tuning
+    const selectedOption = 0;
+    localStorage.setItem("optionVal", selectedOption);
+    selectOptions[0].selected = true;
+    console.log(selectedOption)
+
+    // Set the default of sharp key
+    const savedUserKey = sharpRadioBtn.value;
+    localStorage.setItem("userKey", savedUserKey);
+    sharpRadioBtn.checked = true;
+
     numberInputElements[0].focus();
   } else {
+    // Set the user's Tuning
+    const selectedOption = localStorage.getItem("optionVal");
+    selectOptions[selectedOption].selected = true;
+    console.log(selectedOption)
+    
+    // Set the user's key
+    const savedUserKey = localStorage.getItem("userKey");
+    if (savedUserKey === 'sharp') {
+      sharpRadioBtn.checked = true;
+      console.log("sharp = " + sharpRadioBtn.checked)
+    } else if (savedUserKey === 'flat') {
+      flatRadioBtn.checked = true;
+      console.log("flat = " + flatRadioBtn.checked)
+    }
+
     const selectUserStrings = localStorage.getItem("userStrings");
 
     sixth.innerText = selectUserStrings.split(",")[0];

--- a/js/modules/setTuning.js
+++ b/js/modules/setTuning.js
@@ -14,6 +14,8 @@ export default function setTuning(e) {
 
   const selectedOption = altTuningsElement.options[altTuningsElement.selectedIndex].value;
   const notesOfOpenStrings = TUNINGS[selectedOption].split("-");
+  const sharpRadioBtn = document.querySelector("#sharp-key");
+  const flatRadioBtn = document.querySelector("#flat-key");
 
   // Set the innerText above inputs
   sixth.innerText = notesOfOpenStrings[0];
@@ -31,8 +33,17 @@ export default function setTuning(e) {
     second.innerText, 
     first.innerText
   ];
+
   localStorage.setItem("userStrings", savedUserTuning);
   localStorage.setItem("optionVal", selectedOption);
 
-  pageReset();
+  if (sharpRadioBtn.checked) {
+    const savedUserKey = sharpRadioBtn.value;
+    localStorage.setItem("userKey", savedUserKey);
+  } else if (flatRadioBtn.checked) {
+    const savedUserKey = flatRadioBtn.value;
+    localStorage.setItem("userKey", savedUserKey);
+  }
+
+  // pageReset();
 }

--- a/js/script.js
+++ b/js/script.js
@@ -13,8 +13,8 @@ import outputToDom from "./modules/outputToDom.js";
 const notesFormElement = document.getElementById("notes-form");
 const notesFormSubmitBtn = notesFormElement.querySelector("#form-submit");
 const pageResetBtn = notesFormElement.querySelector("#page-reset");
-const sharpRadioBtn = notesFormElement.querySelector("#sharp-key");
-const flatRadioBtn = notesFormElement.querySelector("#flat-key");
+const sharpRadioBtn = document.querySelector("#sharp-key");
+const flatRadioBtn = document.querySelector("#flat-key");
 const altTuningsFormElement = document.getElementById("tunings-form");
 
 const userChordNotes = [];
@@ -163,6 +163,10 @@ altTuningsFormElement.addEventListener("submit", setTuning);
 notesFormElement.addEventListener("submit", function (e) {
   e.preventDefault();
   getChordName();
+
+  document.querySelector('#notes-heading').scrollIntoView({
+    behavior: 'smooth'
+  });
 });
 
 // 4. SUBMIT BUTTON: Submit button to scroll to results

--- a/what-chord-is-this.html
+++ b/what-chord-is-this.html
@@ -64,11 +64,11 @@
     <div class="container mt-5 mx-auto row justify-content-center">
       <h1 class="mt-5 text-center mt-2 pb-2 border-bottom border-secondary">WHAT CHORD IS THIS?</h1>
       <h2 class="text-center text-secondary">Guitar chord namer app</h2>
-      <h3 class="mb-1 mt-3 text-center"> <span aria-label="	G clef">&#119070;</span> Choose the tuning &amp; enter your
-        fret numbers</h3>
-      <form id="tunings-form" class="col-sm-6 row g-3">
-        <div class="col-md-7">
-          <select id="alt-tunings" class="form-select border border-info" aria-label="Default select example">
+      <h3 class="mb-1 mt-3 text-center"> <span aria-label="	G clef">&#119070;</span> Choose the tuning &amp; a sharp/flat key</h3>
+
+      <form id="tunings-form" class="col-12 col-md-10 row g-3 justify-content-center">
+        <div class="col-md-5">
+          <select name="tuning" id="alt-tunings" class="form-select border border-info" aria-label="Default select example">
             <option value="0">Standard (E-A-D-G-B-E)</option>
             <option value="1">Drop D (D-A-D-G-B-E)</option>
             <option value="2">Dbl Drop D (D-A-D-G-B-D)</option>
@@ -85,13 +85,25 @@
           </select>
         </div>
         <div class="col-md-5">
-          <button id="user-tuning" class="btn btn-primary" type="submit">
-            Set Tuning
+
+          <div class="form-check form-check-inline ms-3 border-bottom border-dark">
+            <input class="form-check-input" type="radio" name="sharps-flats" id="sharp-key" value="sharp">
+            <label class="form-check-label fs-6" for="sharps">Sharp</label>
+          </div>
+          <div class="form-check form-check-inline me-3 border-bottom border-dark">
+            <input class="form-check-input" type="radio" name="sharps-flats" id="flat-key" value="flat">
+            <label class="form-check-label fs-6" for="flats">Flat</label>
+          </div>
+
+          <button id="user-tuning" class="user-tuning btn btn-primary mt-3" type="submit">
+            Set Tuning &amp; Key
           </button>
         </div>
       </form>
     </div>
-    <div class="container mb-5 mx-auto row justify-content-center">
+    <div class="container mt-3 mx-auto row justify-content-center">
+      <h3 id="notes-heading" class="mb-1 mt-3 text-center"> <span aria-label="	G clef">&#119070;</span> Enter your fret numbers
+      </h3>
       <form id="notes-form" class="col-sm-6 row g-3">
         <div class="col-sm-2 custom">
           <label for="str1" class="form-label fade-in-one"><span id="sixth" class="h4 string">E</span></label>
@@ -125,14 +137,6 @@
           <button id="page-reset" class="btn btn-dark mx-2" type="submit">
             RESET
           </button>
-          <div class="form-check form-check-inline ms-3 my-3 border-bottom border-dark">
-            <input class="form-check-input" type="radio" name="sharps-flats" id="sharp-key" value="sharp" checked>
-            <label class="form-check-label fs-5" for="sharps">Sharp keys</label>
-          </div>
-          <div class="form-check form-check-inline my-3 border-bottom border-dark">
-            <input class="form-check-input" type="radio" name="sharps-flats" id="flat-key" value="flat">
-            <label class="form-check-label fs-5" for="flats">Flat keys</label>
-          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
The sharp and flat radio buttons were removed from the notes form and added to the tuning form. Then the tuning and radio buttons were added to `localStorage` so that the tuning selected has the `selected` property and the sharp/flat key selected has the `checked` property. 

Changes also resulted for `setTuning.js` and `script.js`